### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ Then put you routes inside *Transition* component:
 
 ### Guarded routes
 
-You may protect routes from beeing loaded just using Svelte's logic like `{#if}` statement:
+You may protect routes from being loaded just using Svelte's logic like `{#if}` statement:
 
 ```html
 {#if user.authed}


### PR DESCRIPTION
In guarded routes, it says `beeing` instead of `being`