### PR TITLE
Non-exact routes capture wildcard contents as `params['*']`

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,8 @@ You can use param keys in `path` property. See the example:
 
 When you open `/books/stanislav_lem/fiction` in the browser, the `params` object will have the values retrieved from the URL - `{author: "stanislav_lem"}` in the parent route and `{author: "stanislav_lem", genre: "fiction"}` in the child route. 
 
+Non-exact routes capture the wildcard contents under `params['*']`.
+
 There are two ways to get parameters in nested component:
 
 ### Using `let:params` directive:

--- a/src/lib.js
+++ b/src/lib.js
@@ -112,6 +112,7 @@ export function formatPath(path,slash=false){
 }
 
 export function getRouteData(pattern,path){
+    const trailingSlash = path.endsWith('/');
     pattern = formatPath(pattern,true);
     path = formatPath(path,true);
 
@@ -123,13 +124,18 @@ export function getRouteData(pattern,path){
        .map(s => s.startsWith(':') ? (keys.push(s.slice(1)),'([^\\/]+)') : s)
        .join('\\/');
 
-    let match = path.match(new RegExp(`^${rx}$`));
-    if(!match) {
-        exact = false;
-        match = path.match(new RegExp(`^${rx}`));
-    }
+    let match = path.match(new RegExp(`^${rx}(.*)`));
     if(!match) return null;
     keys.forEach((key,i) => params[key] = match[i+1]);
+
+    let wildcard = match[match.length - 1];
+    if(wildcard) {
+        exact = false;
+        if(!trailingSlash) {
+            wildcard = wildcard.slice(0, -1);
+        }
+        params['*'] = wildcard;
+    }
 
     return {exact,params};
 }

--- a/tests/App.svelte
+++ b/tests/App.svelte
@@ -96,6 +96,11 @@
 				<Route path="/foo/:var"><h1 id="notmatch">Only didn't matched subpage - OK</h1></Route>
 			</Route>
 			
+			<Route path="/test13/:foo/*" let:params>
+				<h1>{params.foo}</h1>
+				<h2>{params['*']}</h2>
+			</Route>
+
 			<Route fallback><h1>Root fallback</h1></Route>
 		</Route>
 	</div>

--- a/tests/set/13_wildcard_params.js
+++ b/tests/set/13_wildcard_params.js
@@ -1,0 +1,13 @@
+module.exports = async function (test,page) {test('Wildcard capture', async t =>{
+  await page.go('/test13/abc/def/ghi');
+  t.equal(await page.innerText('h1'),'abc','Normal route params work');
+  t.equal(await page.innerText('h2'),'def/ghi','Wildcard is captured');
+
+  await page.go('/test13/abc/def/ghi/');
+  t.equal(await page.innerText('h1'),'abc','Normal route params work with trailing slash');
+  t.equal(await page.innerText('h2'),'def/ghi/','Wildcard is captured with trailing slash');
+
+  await page.go('/test13/abc/');
+  t.equal(await page.innerText('h1'),'abc','Normal route params work without wildcard contents');
+  t.equal(await page.innerText('h2'),'undefined','Wildcard parameter is not set when it is absent');
+})}


### PR DESCRIPTION
This exposes the contents of a matched wildcard to non-exact routes. It's most useful when the contents of the wildcard needs to be parsed further, used in a fetch request, and so on, but it may contain one or more slashes so a parameter like `:foo` won't work.
