### PR TITLE
fix(types): Improve `get` method on `TinroRouterLocationQuery`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -41,8 +41,10 @@ interface TinroRouterLocationHash {
 }
 
 interface TinroRouterLocationQuery {
-  /** Get the query object or a value from it by property name */ 
-  get(name?:string): Record<string, string>|string
+  /** Get the value by property name */ 
+  get(name:string): string | undefined
+  /** Get the query object */ 
+  get(): Record<string, string>
   /** Update or add a property in the query object */ 
   set(name:string,value:string|number): void
   /** Delete a property from the query object */ 


### PR DESCRIPTION
Currently `router.location.query.get(name?: string)` return is defined as `Record<string, string> | string`.

But this can get confusing, since if passed a `string` we should receive a `string`, and only if no name is passed we should return the entire object as `Record<string, string>`

And if the property hasn't been set, we should also show that the return value could be `undefined`

So this updated type definition should help with that.