### PR TITLE
fix ts error "'typeof Route' is not assignable to"

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+import type { SvelteComponentTyped } from "svelte";
+
 interface TinroRoute {
     url: string
     from: string
@@ -81,7 +83,39 @@ declare interface TinroRouter {
 export const active: any
 export function meta(): TinroRouteMeta
 export const router: TinroRouter
-export class Route {
+
+type RouteArgs = {
+    /**
+    * Exact o relative path of the route
+    * @default "/*"
+    */
+    path?: string;
+
+    /**
+     * Is route fallback
+     * @default false
+     */
+    fallback?: boolean;
+
+    /**
+     * Redirect route to the specified path
+     */
+    redirect?: string;
+
+    /**
+     * Will be show only first matched with URL nested route
+     * @default false
+     */
+    firstmatch?: boolean;
+
+    /**
+     * Name of the route to use in breadcrumbs
+     * @default null
+     */
+    breadcrumb?: string;	
+}
+
+export class Route extends SvelteComponentTyped<RouteArgs> {
     $$prop_def: {
       /**
        * Exact o relative path of the route


### PR DESCRIPTION
An error has occurred on latest versions of typescript (4.8.2), svelte (3.49.0) and tinro (0.6.12 - now the latest version on npm):

![image](https://user-images.githubusercontent.com/40761960/190895143-5b0539f1-b4f9-4e1f-8568-7b43da8a1e12.png)


Full error text: 

```
Argument of type 'typeof Route' is not assignable to parameter of type 'ConstructorOfATypedSvelteComponent'.
  Type 'Route' is missing the following properties from type 'ATypedSvelteComponent': $$events_def, $on
```

This commit completely solved the problem for me